### PR TITLE
Update languge to embrace GPL "friendly" licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Backdrop Contributed Project Group Application
 ==============================================
 
-Use this project to express interest in joining the growing list of developers maintaining a module or theme hosted at https://github.com/backdrop-contrib/.
+Use this project to express interest in joining the growing community of developers maintaining a module or theme hosted at https://github.com/backdrop-contrib/.
 
 To apply simply create a request as an issue at https://github.com/backdrop-ops/contrib/issues/new
 
@@ -16,7 +16,7 @@ By publishing a project in the [Backdrop Contributed Project Group](https://gith
 
 1. You must agree to license your contributions as GPLv2 or later.
 
-1. You must include a copy of the [GPL v2 `LICENSE.txt` file](https://github.com/backdrop-ops/contrib/blob/master/examples/LICENSE.txt) in the root of your repository.  The GPLv2 license applies to all code that directly interacts with parts of Backdrop licensed as GPLv2 or later.   
+1. You must include a copy of the [GPL v2 `LICENSE.txt` file](https://github.com/backdrop-ops/contrib/blob/master/examples/LICENSE.txt) in the root of your repository.  The GPLv2 license applies to all code that directly interacts with parts of Backdrop licensed as GPLv2 or later.  See for the [Backdrop License FAQ](https://backdropcms.org/license) for a more detailed explaination.    
 
 1. You must confirm that you have the right to distribute any additional code, libraries, images, fonts or other assets written or created by any third party with code licensed as GPLv2 or later. 
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,30 @@
 Backdrop Contributed Project Group Application
 ==============================================
 
-This project allows you to apply to join the [contributed project developer team](https://github.com/backdrop-contrib/).
+Use this project to express interest in joining the growing list of developers maintaining a module or theme hosted at https://github.com/backdrop-contrib/.
 
 To apply simply create a request as an issue at https://github.com/backdrop-ops/contrib/issues/new
 
-If you have already written or ported a project to Backdrop, please include a link to the module or theme you have written, hosted either on Github under a personal account or elsewhere. After joining the Backdrop Contributed Project Group, you will be able to transfer the entire repository to live under `https://github.com/backdrop-contrib/[your_project_name]`
+You don't have to wait for access to Backdrop Contributed Project Group to share your code, nor is it required.  You can start writing or porting a project to Backdrop in your own GitHub account (or under a personal account hosted elsewhere). If you've already started a project, please include a link to the module or theme you have written. After joining the Backdrop Contributed Project Group, you will be able to transfer the entire repository to live under `https://github.com/backdrop-contrib/[your_project_name]`
 
 Backdrop Contributed Project Author Agreement
 ---------------------------------------------
 
-By publishing a project in the [Backdrop Contributed project group](https://github.com/backdrop-contrib) (Backdrop Contrib for short), you must agree to the following:
+By publishing a project in the [Backdrop Contributed Project Group](https://github.com/backdrop-contrib) (Backdrop Contrib for short), you must agree to the following:
 
 1. You will not push changes to a repository for which you are not a maintainer; even though joining the Backdrop Contrib group will grant you technical permission to push to any project within.
 
-1. You must include a copy of the [GPL v2 `LICENSE.txt` file](https://github.com/backdrop-ops/contrib/blob/master/examples/LICENSE.txt) in the root of your repository.
+1. You must agree to license your contributions as GPLv2 or later.
+
+1. You must include a copy of the [GPL v2 `LICENSE.txt` file](https://github.com/backdrop-ops/contrib/blob/master/examples/LICENSE.txt) in the root of your repository.  This license applies to all PHP code executed by Backdrop.  
+
+1. You must confirm that you have the right to distribute any additional code, libraries, images, fonts or other assets written or created by any third party with code licensed as GPLv2 or later. 
 
 1. You must include a `README.md` with all projects, including at the least the following:
   1. A description of the project
   1. Basic documentation
-  1. License information (GPL v2)
+  1. License information for the project (GPL v2)
+  1. License information for any additional assets (SIL OFL fonts, CC-SA images, etc) 
   1. A list of the current maintainers for the Backdrop project
   1. A list of the past maintainers for the Backdrop or Drupal project
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ By publishing a project in the [Backdrop Contributed Project Group](https://gith
 
 1. You must agree to license your contributions as GPLv2 or later.
 
-1. You must include a copy of the [GPL v2 `LICENSE.txt` file](https://github.com/backdrop-ops/contrib/blob/master/examples/LICENSE.txt) in the root of your repository.  This license applies to all PHP code executed by Backdrop.  
+1. You must include a copy of the [GPL v2 `LICENSE.txt` file](https://github.com/backdrop-ops/contrib/blob/master/examples/LICENSE.txt) in the root of your repository.  The GPLv2 license applies to all code that directly interacts with parts of Backdrop licensed as GPLv2 or later.   
 
 1. You must confirm that you have the right to distribute any additional code, libraries, images, fonts or other assets written or created by any third party with code licensed as GPLv2 or later. 
 


### PR DESCRIPTION
These are mainly changes to make it clear that Backdrop projects do not have to be hosted in Backdrop Contrib and that GitHub.com doesn't have the same license requirements as Drupal.org.  Users should be allowed to commit images, fonts, and code using licenses that allow the assets to be distributed within a GPLv2 project.

This goes back to https://www.drupal.org/node/1856762 

While we are slowly making progress on getting past the GPLv2 only mindset for all assets some early Drupal contributors still cling to, there is no reason Backdrop should adhere to developer centric Drupal.org policies created ~10 years ago when disk space was a concern.  What kind of modern, enterprise ready project makes statements like https://www.drupal.org/licensing/faq#q10

> Doing so creates a fork of that 3rd party library, which makes it more difficult to maintain and only serves to waste disk space.

Requiring what is contributed to Backdrop Contrib to use a license that allows it to be distributed within a GPLv2 project rules out anything using an Apache2 license, but it makes it clear other GPL friendly licenses for non-code assets are allowed.

While Drupal modules like https://www.drupal.org/project/fontawesome add both a Drush .make and .inc to make it as easy as possible to install the required library while adhering to very a dated licensing policy, WordPress users can simply install https://wordpress.org/plugins/font-awesome/... which is hosted on https://github.com/rachelbaker/Font-Awesome-WordPress-Plugin... and has 48 forks.  

WordPress's approach works better for both site builders and developers.

Unless https://github.com/backdrop-contrib has the same goal Drupal.org's contrib repo had for years... "everything you download from Drupal.org is GPLv2", please adopt language that embraces the fact that open licenses go beyond code and that an asset can be GPL friendly without being strictly GPLv2 compatible.